### PR TITLE
Change localgov_user_manager role to the RolesHelper::USER_MANAGER_ROLE constant

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
       "drupal/tasty_backend": "^1.0@beta",
       "drupal/tasty_backend_gin": "^1.0@alpha",
       "drupal/tasty_backend_media": "^1.0@beta",
-      "localgovdrupal/localgov_core": "^2.13.0",
+      "localgovdrupal/localgov_core": "^2.13.1",
       "php": ">=8.0.0"
   }
 }

--- a/localgov_tasty_backend.module
+++ b/localgov_tasty_backend.module
@@ -24,9 +24,10 @@ function localgov_tasty_backend_localgov_roles_default(): array {
     RolesHelper::CONTRIBUTOR_ROLE => $tb_permissions,
 
     // Allow user manager to assign content admin role.
-    'localgov_user_manager' => [
+    RolesHelper::USER_MANAGER_ROLE => [
       'assign content_admin role',
       'assign tb_media_admin role',
+      'view tb_manage in toolbar',
     ],
   ];
 


### PR DESCRIPTION
Fix #5

- Sets minimum localgov_core version to 2.13.1
- Adds permission to user manager to access the tasty backend manage toolbar
