### PR TITLE
Use view as main alert banners route and entity collection as fallback

### DIFF
--- a/localgov_tasty_backend.module
+++ b/localgov_tasty_backend.module
@@ -84,6 +84,7 @@ function localgov_tasty_backend_menu_links_discovered_alter(&$links) {
       'weight' => -1,
     ];
   }
+  // Content moderation fallback.
   elseif (_localgov_tasty_backend_route_exists('content_moderation.admin_moderated_content')) {
     $links['localgov_tasty_backend.content_moderation.admin_moderated_content'] = [
       'title' => t('Moderated content'),
@@ -132,7 +133,16 @@ function localgov_tasty_backend_menu_links_discovered_alter(&$links) {
     ];
   }
   // Alert banners.
-  if (_localgov_tasty_backend_route_exists('entity.localgov_alert_banner.collection')) {
+  if (_localgov_tasty_backend_route_exists('view.localgov_admin_manage_alert_banners.localgov_alert_banner_admin_list')) {
+    $links['localgov_tasty_backend.view.localgov_admin_manage_alert_banners.localgov_alert_banner_admin_list'] = [
+      'title' => t('Alert banners'),
+      'route_name' => 'view.localgov_admin_manage_alert_banners.localgov_alert_banner_admin_list',
+      'parent' => 'localgov_tasty_backend.manage_site_page',
+      'menu_name' => 'tb-manage',
+    ];
+  }
+  // Alert banners fallback.
+  elseif (_localgov_tasty_backend_route_exists('entity.localgov_alert_banner.collection')) {
     $links['localgov_tasty_backend.entity.localgov_alert_banner.collection'] = [
       'title' => t('Alert banners'),
       'route_name' => 'entity.localgov_alert_banner.collection',


### PR DESCRIPTION
Fix #10

Also comment updates.
