### PR TITLE
Set names of toolbar menus

### DIFF
--- a/localgov_tasty_backend.install
+++ b/localgov_tasty_backend.install
@@ -31,7 +31,7 @@ function localgov_tasty_backend_install($is_syncing) {
   // Rename the manage menu to administration.
   \Drupal::configFactory()
     ->getEditable('toolbar_menu.toolbar_menu_element.tb_manage')
-    ->set('label', 'Administration')
+    ->set('label', 'Manage website')
     ->save();
 
   // Delete tasty backend user_admin role in favour of localgov_user_manager.

--- a/localgov_tasty_backend.module
+++ b/localgov_tasty_backend.module
@@ -206,6 +206,15 @@ function localgov_tasty_backend_menu_links_discovered_alter(&$links) {
 }
 
 /**
+ * Implements hook_toolbar_alter().
+ */
+function localgov_tasty_backend_toolbar_alter(&$items) {
+  if (!empty($items['administration'])) {
+    $items['administration']['tab']['#title'] = t('Administration');
+  }
+}
+
+/**
  * Check if a route exits without raising exception.
  *
  * @param string $route_to_check


### PR DESCRIPTION
Fix #6

Renames the core 'Manage' toolbar name to Adminstration as it uses the administration menu
This has to be done through hook_toolbar_alter.

Renames the tasty backend 'Manage' toolbar name from Adminsitration as previous to 'Manage website'
As this is managed by Toolbar menu, its set up during initial install.
