### PR TITLE
Assign the emergency publisher role the default tb permissions

### DIFF
--- a/localgov_tasty_backend.module
+++ b/localgov_tasty_backend.module
@@ -24,6 +24,7 @@ function localgov_tasty_backend_localgov_roles_default(): array {
     RolesHelper::EDITOR_ROLE => $tb_permissions,
     RolesHelper::AUTHOR_ROLE => $tb_permissions,
     RolesHelper::CONTRIBUTOR_ROLE => $tb_permissions,
+    'emergency_publisher' => $tb_permissions,
 
     // Allow user manager to assign content admin role.
     RolesHelper::USER_MANAGER_ROLE => [


### PR DESCRIPTION
Fix #27

Allows the emergency publisher to access the tasty backend toolbar
