### PR TITLE
Fix the spacing toolbar <nolink> links in classic toolbar

### DIFF
--- a/css/classic-toolbar-tweaks.css
+++ b/css/classic-toolbar-tweaks.css
@@ -1,0 +1,6 @@
+[dir="ltr"] .toolbar-menu .menu-item > span {
+  padding-left: 1.25em;
+}
+[dir="rtl"] .toolbar-menu .menu-item > span {
+  padding-right: 1.25em;
+}

--- a/localgov_tasty_backend.libraries.yml
+++ b/localgov_tasty_backend.libraries.yml
@@ -1,0 +1,7 @@
+classic_toolbar_tweaks:
+  version: VERSION
+  css:
+    theme:
+      css/classic-toolbar-tweaks.css: {}
+  dependencies:
+    - gin/gin_classic_toolbar

--- a/localgov_tasty_backend.module
+++ b/localgov_tasty_backend.module
@@ -301,11 +301,18 @@ function localgov_tasty_backend_modules_installed(array $modules, bool $is_synci
  * Implements hook_preprocess_HOOK() for toolbar.
  */
 function localgov_tasty_backend_preprocess_toolbar(&$variables) {
-  $toolbar_variant = $variables['toolbar_variant'];
 
-  // Remove the extra padding added by Gin theme to <nolink> parent menus.
-  if ($toolbar_variant == 'classic') {
-    $variables['#attached']['library'][] = 'localgov_tasty_backend/classic_toolbar_tweaks';
+  // Apply alterations only with Gin theme.
+  $admin_theme = \Drupal::config('system.theme')->get('admin');
+  $admin_theme_name = \Drupal::service('theme_handler')->getName($admin_theme);
+  if ($admin_theme_name == 'Gin') {
+
+    $toolbar_variant = $variables['toolbar_variant'];
+
+    // Remove the extra padding added by Gin theme to <nolink> parent menus.
+    if ($toolbar_variant == 'classic') {
+      $variables['#attached']['library'][] = 'localgov_tasty_backend/classic_toolbar_tweaks';
+    }
   }
 }
 

--- a/localgov_tasty_backend.module
+++ b/localgov_tasty_backend.module
@@ -307,7 +307,7 @@ function localgov_tasty_backend_preprocess_toolbar(&$variables) {
   $admin_theme_name = \Drupal::service('theme_handler')->getName($admin_theme);
   if ($admin_theme_name == 'Gin') {
 
-    $toolbar_variant = $variables['toolbar_variant'];
+    $toolbar_variant = $variables['toolbar_variant'] ?? '';
 
     // Remove the extra padding added by Gin theme to <nolink> parent menus.
     if ($toolbar_variant == 'classic') {

--- a/localgov_tasty_backend.module
+++ b/localgov_tasty_backend.module
@@ -5,6 +5,7 @@
  * Localgov tasty backend module file.
  */
 
+use Drupal\Core\Asset\AttachedAssetsInterface;
 use Drupal\localgov_roles\RolesHelper;
 use Drupal\user\Entity\Role;
 use Symfony\Component\Routing\Exception\RouteNotFoundException;
@@ -293,5 +294,31 @@ function localgov_tasty_backend_modules_installed(array $modules, bool $is_synci
       'config' => 'system.menu.tb-manage',
       'module' => 'localgov_tasty_backend',
     ]);
+  }
+}
+
+/**
+ * Implements hook_preprocess_HOOK() for toolbar.
+ */
+function localgov_tasty_backend_preprocess_toolbar(&$variables) {
+  $toolbar_variant = $variables['toolbar_variant'];
+
+  // Remove the extra padding added by Gin theme to <nolink> parent menus.
+  if ($toolbar_variant == 'classic') {
+    $variables['#attached']['library'][] = 'localgov_tasty_backend/classic_toolbar_tweaks';
+  }
+}
+
+/**
+ * Implements hook_css_alter().
+ */
+function localgov_tasty_backend_css_alter(&$css, AttachedAssetsInterface $assets) {
+
+  // Makes sure classic_toolbar_tweaks is output after Gin.
+  $library = \Drupal::service('library.discovery')->getLibraryByName('localgov_tasty_backend', 'classic_toolbar_tweaks');
+  $path = $library['css'][0]['data'];
+
+  if (isset($css[$path])) {
+    $css[$path]['group'] = 300;
   }
 }


### PR DESCRIPTION
Fix #23

When using the classic toolbar, Gin theme adds extra padding to parent menu
items that are <nolink> (just span). This means the menu link group have
extra spacing, which this removes.
